### PR TITLE
3dzplane

### DIFF
--- a/laplace_system_analysis/bodeplot_example_approximations_pzmaps3D.ipynb
+++ b/laplace_system_analysis/bodeplot_example_approximations_pzmaps3D.ipynb
@@ -83,7 +83,7 @@
     "print(xa_max, xa_min)\n",
     "\n",
     "fig = plt.figure(figsize=(6, 5))\n",
-    "ax = fig.gca(projection='3d')\n",
+    "ax = fig.add_subplot(projection='3d')\n",
     "Ncol = 72//6\n",
     "col_tick = np.linspace(-36, 36, Ncol, endpoint=False)\n",
     "cmap = mpl.cm.get_cmap('cividis')\n",
@@ -134,9 +134,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mydsp",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "mydsp"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/z_system_analysis/ztransferfunction_pzmaps3D.ipynb
+++ b/z_system_analysis/ztransferfunction_pzmaps3D.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Sascha Spors](https://orcid.org/0000-0001-7225-9992),\n",
+    "Professorship Signal Theory and Digital Signal Processing,\n",
+    "[Institute of Communications Engineering (INT)](https://www.int.uni-rostock.de/),\n",
+    "Faculty of Computer Science and Electrical Engineering (IEF),\n",
+    "[University of Rostock, Germany](https://www.uni-rostock.de/en/)\n",
+    "\n",
+    "# Tutorial Signals and Systems (Signal- und Systemtheorie)\n",
+    "\n",
+    "Summer Semester 2021 (Bachelor Course #24015)\n",
+    "\n",
+    "- lecture: https://github.com/spatialaudio/signals-and-systems-lecture\n",
+    "- tutorial: https://github.com/spatialaudio/signals-and-systems-exercises\n",
+    "\n",
+    "WIP...\n",
+    "The project is currently under heavy development while adding new material for the summer semester 2021\n",
+    "\n",
+    "Feel free to contact lecturer [frank.schultz@uni-rostock.de](https://orcid.org/0000-0002-3010-0294)\n",
+    "\n",
+    "## Übung / Exercise 9: z Transform\n",
+    "\n",
+    "- initially authored by https://github.com/robhau, adapted by https://github.com/fs446"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-25T13:00:38.137146Z",
+     "iopub.status.busy": "2021-03-25T13:00:38.136741Z",
+     "iopub.status.idle": "2021-03-25T13:00:38.408370Z",
+     "shell.execute_reply": "2021-03-25T13:00:38.408771Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import sys\n",
+    "from mpl_toolkits.mplot3d import Axes3D\n",
+    "from scipy.signal import tf2zpk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_fol = os.getcwd()\n",
+    "print(cur_fol)\n",
+    "sys.path.append(cur_fol + '/../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sig_sys_tools import plot_dtlti_analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Transfer Function of a Discrete-Time LTI System\n",
+    "\n",
+    "A simple, causal system is given by its transfer function in $z$ domain  \n",
+    "$$H(z) = \\frac{1}{2} \\cdot \\frac{z-3}{z-\\frac{3}{4}} = \\frac{1}{2} \\cdot \\frac{1 - 3 z^{-1}}{1 - \\frac{3}{4} z^{-1}}$$\n",
+    "with pole $z_{\\infty}=\\frac{3}{4}$, zero $z_0=3$ and gain factor $k=\\frac{1}{2}$. Region of convergence follows from the pole and is thus $|z|>\\frac{1}{3}$.\n",
+    "Let us set up this system first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z0 = 3\n",
+    "zoo = 3/4\n",
+    "k = 1/2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Frequency and Time Response\n",
+    "\n",
+    "As next step, let us render the usual plots of the LTI system characteristics in time and frequency domain. For that we can use the convenient function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_dtlti_analysis(z0, zoo, k)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that this simple system has lowpass characteristics since the pole dominates the influence what is going on along the unit circle (i.e. where we evaluate the $z$-transfer function to get the frequency response of the system).\n",
+    "\n",
+    "### 3D Surface Plot of the Transfer Function\n",
+    "\n",
+    "We can further visualize $|H(z)|$ over the $z$ plane to get an impression why the pole actually is responsible for the observed lowpass characteristics. Please check the black circle which is $20 \\log_{10} |H(z)|$ in dB for all $|z|=1$ (i.e. evaluation on the unit circle). The pole (high level, red color) and the zero (low level, blue color) is easily seen in the 3D plot below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-25T13:00:38.440355Z",
+     "iopub.status.busy": "2021-03-25T13:00:38.434050Z",
+     "iopub.status.idle": "2021-03-25T13:00:45.149481Z",
+     "shell.execute_reply": "2021-03-25T13:00:44.982847Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "N = 2**9\n",
+    "m_z = np.linspace(1e-6, 5, N)\n",
+    "p_z = np.linspace(0, 2*np.pi, N)\n",
+    "magnitude_z, phase_z = np.meshgrid(m_z, p_z, sparse=False, indexing='xy')\n",
+    "z = magnitude_z*np.exp(1j*phase_z)\n",
+    "ejomega = np.exp(1j*phase_z)\n",
+    "\n",
+    "H_z = k * (z - z0) / (z - zoo)\n",
+    "H_ejomega = k * (ejomega-z0) / (ejomega - zoo)\n",
+    "\n",
+    "xa = 20*np.log10(np.abs(H_z))\n",
+    "xfta = 20*np.log10(np.abs(H_ejomega))\n",
+    "xa_max = np.max(xa)\n",
+    "xa_min = np.min(xa)\n",
+    "print(xa_max,\n",
+    "      xa_min,\n",
+    "      20*np.log10(xa_max),\n",
+    "      20*np.log10(np.abs(xa_min)))  # to check resolution of colormap/-bar\n",
+    "\n",
+    "fig = plt.figure(figsize=(6, 5))\n",
+    "ax = fig.add_subplot(projection='3d')\n",
+    "Ncol = (36+42)//6\n",
+    "col_tick = np.linspace(-36, 42, Ncol, endpoint=False)\n",
+    "cmap = mpl.cm.get_cmap('Spectral_r')\n",
+    "norm = mpl.colors.BoundaryNorm(col_tick, cmap.N)\n",
+    "surf = ax.plot_surface(magnitude_z*np.cos(phase_z),\n",
+    "                       magnitude_z*np.sin(phase_z),\n",
+    "                       xa,\n",
+    "                       cmap=cmap, norm=norm,\n",
+    "                       rstride=5, cstride=5, linewidth=0, alpha=1)\n",
+    "ax.plot3D(np.real(ejomega)[:, N//2], np.imag(ejomega)[:, N//2],\n",
+    "          xfta[:, N//2], 'k', lw=3, alpha=1)\n",
+    "\n",
+    "cbar = fig.colorbar(surf, ax=ax, ticks=col_tick,\n",
+    "                    label=r'$|H(z)|$ in dB', pad=0.15)\n",
+    "# TBD: location='left' in newer matplotlib version\n",
+    "ax.set_xlabel(r'$\\Re(z)$')\n",
+    "ax.set_ylabel(r'$\\Im(z)$')\n",
+    "ax.set_zlabel(r'$|H(z)|$ in dB')\n",
+    "#ax.view_init(azim=-60, elev=30)\n",
+    "#print(ax.azim, ax.elev)\n",
+    "ax.set_xlim(-5, 5)\n",
+    "ax.set_xticks(np.arange(-5, 6, 1))\n",
+    "ax.set_ylim(-5, 5)\n",
+    "ax.set_yticks(np.arange(-5, 6, 1))\n",
+    "ax.set_zlim(-36, 36)\n",
+    "ax.set_zticks(np.arange(-36, 36+6, 6))\n",
+    "ax.set_zticklabels(['-36', ' ', '-24', ' ', '-12', ' ',\n",
+    "                   '0', ' ', '12', ' ', '24', ' ', '36'])\n",
+    "plt.savefig('ztransferfunction_pzmaps3D.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Question: What frequency response do we expect when we shift the zero to `z0 = 4/3`, i.e. closer to the unit circle. Can we explain this by interpreting the influence of the pole and the zero with respect to the unit circle.\n",
+    "\n",
+    "Question: Can we use the inverted system for any practical purpose? Why (not)?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Copyright\n",
+    "\n",
+    "This tutorial is provided as Open Educational Resource (OER), to be found at\n",
+    "https://github.com/spatialaudio/signals-and-systems-exercises\n",
+    "accompanying the OER lecture\n",
+    "https://github.com/spatialaudio/signals-and-systems-lecture.\n",
+    "Both are licensed under a) the Creative Commons Attribution 4.0 International\n",
+    "License for text and graphics and b) the MIT License for source code.\n",
+    "Please attribute material from the tutorial as *Frank Schultz,\n",
+    "Continuous- and Discrete-Time Signals and Systems - A Tutorial Featuring\n",
+    "Computational Examples, University of Rostock* with\n",
+    "``main file, github URL, commit number and/or version tag, year``."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mydsp",
+   "language": "python",
+   "name": "mydsp"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hello,
this is a jupyter notebook based on [this 3d bode plot](https://github.com/spatialaudio/signals-and-systems-exercises/blob/master/laplace_system_analysis/bodeplot_example_approximations_pzmaps3D.ipynb), but for a discret system function. Only the ROC is plotted. If the whole z-plane should be plotted, then `m_z = np.linspace(np.abs(real+imag*1j)+0.00001, 5, N)` have to replaced by `m_z = np.linspace(0, 5, N)`.
I dont know how the pdf name is created. If it should be a different name, `plt.savefig('bodeplot_example_approximations_pzmaps3D_44EB4169E9.pdf')
` has to be changed.
A title is also needed.
In both notebooks i also changed  `ax = fig.gca(projection='3d')` into `ax = fig.add_subplot(projection='3d')`, because when using gca i get a deprecation warning. Subplot example is used [here](https://stackoverflow.com/questions/67095247/gca-and-latest-version-of-matplotlib) and [here](https://stackoverflow.com/questions/27221009/fig-gca-vs-fig-add-subplot) it is said it would be the prefered way.