### PR TITLE
fix plotsplane,, converting array arguments into numpy arrays

### DIFF
--- a/laplace_system_analysis/TestingNewFunctions.ipynb
+++ b/laplace_system_analysis/TestingNewFunctions.ipynb
@@ -41,7 +41,8 @@
     "import sys\n",
     "cur_fol = os.getcwd()\n",
     "print(cur_fol)\n",
-    "sys.path.append(cur_fol + '/../')"
+    "sys.path.append(cur_fol + '/../')\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -80,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_splane(z=np.array([]), p=np.array([-3/4+1j, -3/4-1j]), k=25/16)"
+    "plot_splane(z=np.array([-3/4+1j, -3/4-1j]), p=np.array([-3/4+1j, -3/4-1j]), k=25/16)"
    ]
   },
   {
@@ -90,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_splane(z=[], p=[-3/4+1j, -3/4-1j], k=25/16)"
+    "plot_splane(z=np.array([]), p=np.array([-3/4+1j, -3/4-1j]), k=25/16)"
    ]
   },
   {
@@ -198,9 +199,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mydsp",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "mydsp"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -212,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/sig_sys_tools.py
+++ b/sig_sys_tools.py
@@ -192,12 +192,26 @@ def plot_splane(z, p, k):
     Note that the for-loop handling might be not very efficient
     for very long FIRs
 
-    z...array of zeros in s-plane
-    p...array of poles in s-zplane
+    z...numpy array of zeros in s-plane
+    p...numpy array of poles in s-zplane
     k...gain factor
 
     """
-    
+    z = np.array(z)
+    p = np.array(p)
+    i = 0
+    j = 0
+    while i < z.size:
+        while j < p.size:
+            if z[i]==p[j]:
+                z = np.delete(z,i)
+                p = np.delete(p,j)
+                i = i -1
+                break
+            else:
+                j = j+1
+        j = 0
+        i = i +1
     try: 
         xmax = np.amax(np.real(z))
         xmin = np.amin(np.real(z))
@@ -293,6 +307,8 @@ def plot_clti_analysis(z, p, k,):
         frequency response (level/phase/group delay)
         s-plane of transfer function H(s) given as zeros/poles/gain desciption
     """
+    z = np.array(z)
+    p = np.array(p)
     # still hard coded, TBD:
     # figure size
 


### PR DESCRIPTION
I hope that the problem in plotsplane() is now solved. Now there is a algorithm at the beginning of plotsplane() that remove Z from z and P from p if z ==p.
Also the function arguments can be normal arrays because they are converted into numpy arrays.